### PR TITLE
Add basic support for non-AVR Arduinos

### DIFF
--- a/DirectIO.h
+++ b/DirectIO.h
@@ -127,31 +127,6 @@ class OutputLow {
         }
 };
 
-template <>
-class Output<NO_PIN> {
-    // This specialization of Output is used when a module supports
-    // an optional pin and that pin is not being used. For example,
-    // if a chip supports an Output Enable pin but it is wired
-    // permanently HIGH in the circuit, there won't be an actual
-    // output pin connected to it. In the software, we will use this
-    // type of Output which is basically a no-op.
-    public:
-        Output(boolean initial_value=LOW) {}
-        void write(boolean value) {}
-        Output& operator =(boolean value) {
-            return *this;
-        }
-        void toggle() {}
-        void pulse(boolean value=HIGH) {}
-
-        boolean read() {
-            return LOW;
-        }
-        operator boolean() {
-            return read();
-        }
-};
-
 class OutputPin {
     // An digital output where the pin isn't known at compile time.
     // We cache the port address and bit mask for the pin
@@ -312,85 +287,6 @@ class OutputPort<port, 0, 8> {
         }
         operator u8() {
             return read();
-        }
-};
-
-template<u8 pin>
-class AnalogInput {
-    public:
-        AnalogInput() {}
-
-        u16 read() {
-            return analogRead(pin);
-        }
-
-        operator u16 () {
-            return read();
-        }
-};
-
-template<u8 pin>
-class AnalogOutput {
-    public:
-        AnalogOutput(u8 initial_value=0) {
-            write(initial_value);
-        }
-
-        void write(u8 value) {
-            analogWrite(pin, value);
-        }
-
-        AnalogOutput& operator = (u8 value) {
-            write(value);
-            return *this;
-        }
-};
-
-template<>
-class AnalogOutput<NO_PIN> {
-    // This specialization of AnalogOutput is used when a module supports
-    // an optional pin and that pin is not being used. For example,
-    // the sample LCD project includes a backlight pin which can optionally
-    // be driven with PWM. Alternatively, it could be wired to Vcc to keep
-    // the backlight fully on. In that case, we will use this
-    // type of AnalogOutput which is basically a no-op.
-    public:
-        AnalogOutput(u8 initial_value=0) {}
-        void write(u8 value) {}
-
-        AnalogOutput& operator = (u8 value) {
-            return *this;
-        }
-};
-
-template<u8 pin>
-class AnalogOutputLow {
-    public:
-        AnalogOutputLow(u8 initial_value=0) {
-            write(initial_value);
-        }
-
-        void write(u8 value) {
-            analogWrite(pin, 255 - value);
-        }
-
-        AnalogOutputLow& operator = (u8 value) {
-            write(value);
-            return *this;
-        }
-};
-
-template<>
-class AnalogOutputLow<NO_PIN> {
-    // This specialization of AnalogOutputLow is used when a module supports
-    // an optional pin and that pin is not being used.
-    // See AnalogOutput<NO_PIN> for details.
-    public:
-        AnalogOutputLow(u8 initial_value=0) {}
-        void write(u8 value) {}
-
-        AnalogOutputLow& operator = (u8 value) {
-            return *this;
         }
 };
 

--- a/DirectIO.h
+++ b/DirectIO.h
@@ -25,6 +25,8 @@
 typedef volatile u8* port_t;
 const u8 NO_PIN = 255;
 
+#ifndef DIRECTIO_FALLBACK
+
 template <u8 pin>
 class Input {
     // An standard digital input. read() returns true if the signal is asserted (high).
@@ -58,38 +60,6 @@ class InputPin {
         port_t    in_port;
         u8        mask;
 };
-
-template <u8 pin>
-class InputLow {
-    // An active low digital input. read() returns true if the signal is asserted (low).
-    public:
-        InputLow() {}
-        boolean read() {
-            return ! input.read();
-        }
-        operator boolean() {
-            return read();
-        }
-
-    private:
-        Input<pin> input;
-};
-
-// This macro lets you temporarily set an output to a value,
-// and toggling back at the end of the code block. For example:
-//
-// Output<2> cs;
-// Output<3> data;
-// with(cs, LOW) {
-//     data = HIGH;
-// }
-//
-// is equivalent to:
-// cs = LOW;
-// data = HIGH;
-// cs = HIGH;
-
-#define with(pin, val) for(boolean _loop_##pin=((pin=val),true);_loop_##pin; _loop_##pin=((pin=!val), false))
 
 template <u8 pin>
 class Output {
@@ -344,6 +314,296 @@ class OutputPort<port, 0, 8> {
             return read();
         }
 };
+
+template<u8 pin>
+class AnalogInput {
+    public:
+        AnalogInput() {}
+
+        u16 read() {
+            return analogRead(pin);
+        }
+
+        operator u16 () {
+            return read();
+        }
+};
+
+template<u8 pin>
+class AnalogOutput {
+    public:
+        AnalogOutput(u8 initial_value=0) {
+            write(initial_value);
+        }
+
+        void write(u8 value) {
+            analogWrite(pin, value);
+        }
+
+        AnalogOutput& operator = (u8 value) {
+            write(value);
+            return *this;
+        }
+};
+
+template<>
+class AnalogOutput<NO_PIN> {
+    // This specialization of AnalogOutput is used when a module supports
+    // an optional pin and that pin is not being used. For example,
+    // the sample LCD project includes a backlight pin which can optionally
+    // be driven with PWM. Alternatively, it could be wired to Vcc to keep
+    // the backlight fully on. In that case, we will use this
+    // type of AnalogOutput which is basically a no-op.
+    public:
+        AnalogOutput(u8 initial_value=0) {}
+        void write(u8 value) {}
+
+        AnalogOutput& operator = (u8 value) {
+            return *this;
+        }
+};
+
+template<u8 pin>
+class AnalogOutputLow {
+    public:
+        AnalogOutputLow(u8 initial_value=0) {
+            write(initial_value);
+        }
+
+        void write(u8 value) {
+            analogWrite(pin, 255 - value);
+        }
+
+        AnalogOutputLow& operator = (u8 value) {
+            write(value);
+            return *this;
+        }
+};
+
+template<>
+class AnalogOutputLow<NO_PIN> {
+    // This specialization of AnalogOutputLow is used when a module supports
+    // an optional pin and that pin is not being used.
+    // See AnalogOutput<NO_PIN> for details.
+    public:
+        AnalogOutputLow(u8 initial_value=0) {}
+        void write(u8 value) {}
+
+        AnalogOutputLow& operator = (u8 value) {
+            return *this;
+        }
+};
+
+#else // DIRECTIO_FALLBACK
+
+// These classes offer compatilbity with alternate Arduino-compatible devices, so
+// that libraries can depend on DirectIO without limiting portability.
+// These classes delegate to digitalRead and digitalWrite, so they trade off
+// performance for portability.
+template <u8 pin>
+class Input {
+    // An standard digital input. read() returns true if the signal is asserted (high).
+    public:
+        Input(boolean pullup=true) {
+            pinMode(pin, pullup ? INPUT_PULLUP : INPUT);
+        }
+        boolean read() {
+            return digitalRead(pin);
+        }
+        operator boolean() {
+            return read();
+        }
+};
+
+class InputPin {
+    // An digital input where the pin isn't known at compile time.
+    public:
+        InputPin(u8 pin, boolean pullup=true);
+
+        boolean read() {
+            return digitalRead(pin);
+        }
+        operator boolean() {
+            return read();
+        }
+
+    private:
+        u8 pin;
+};
+
+template <u8 pin>
+class Output {
+    // A standard digital output 
+    public:
+        Output(boolean initial_value=LOW) {
+            pinMode(pin, OUTPUT);
+            digitalWrite(pin, initial_value);
+        }
+        void write(boolean value) {
+            digitalWrite(pin, value);
+        }
+        Output& operator =(boolean value) {
+            write(value);
+            return *this;
+        }
+        void toggle() {
+            write(! read());
+        }
+        void pulse(boolean value=HIGH) {
+            write(value);
+            write(! value);
+        }
+        boolean read() {
+            return digitalRead(pin);
+        }
+        operator boolean() {
+            return read();
+        }
+};
+
+template <u8 pin>
+class OutputLow {
+    // An digital output with direct port I/O
+    public:
+        OutputLow(boolean initial_value=HIGH) {
+            pinMode(pin, OUTPUT);
+            digitalWrite(pin, initial_value);
+        }
+        void write(boolean value) {
+            digitalWrite(pin, !value);
+        }
+        OutputLow& operator =(boolean value) {
+            write(value);
+            return *this;
+        }
+        void toggle() {
+            write(! read());
+        }
+        void pulse(boolean value=LOW) {
+            write(value);
+            write(! value);
+        }
+        boolean read() {
+            return !digitalRead(pin);
+        }
+        operator boolean() {
+            return read();
+        }
+};
+
+class OutputPin {
+    // An digital output where the pin isn't known at compile time.
+    // We cache the port address and bit mask for the pin
+    // and write() writes directly to port memory.
+    public:
+        OutputPin(u8 pin, boolean initial_value=LOW);
+
+        void write(boolean value) {
+            digitalWrite(pin, !value);
+        }
+        OutputPin& operator =(boolean value) {
+            write(value);
+            return *this;
+        }
+        void toggle() {
+            write(! read());
+        }
+        void pulse(boolean value=HIGH) {
+            write(value);
+            write(! value);
+        }
+        boolean read() {
+            return digitalRead(pin);
+        }
+        operator boolean() {
+            return read();
+        }
+
+    private:
+        u8 pin;
+};
+
+inline InputPin::InputPin(u8 pin, boolean pullup) :
+    pin(pin)
+{
+    pinMode(pin, pullup ? INPUT_PULLUP : INPUT);
+
+    // include a call to digitalRead here which will
+    // turn off PWM on this pin, if needed
+    (void) digitalRead(pin);
+}
+
+inline OutputPin::OutputPin(u8 pin, boolean initial_state):
+    pin(pin)
+{
+    pinMode(pin, OUTPUT);
+
+    // include a call to digitalWrite here which will
+    // set the initial state and turn off PWM
+    // on this pin, if needed.
+    digitalWrite(pin, initial_state);
+}
+
+#endif // DIRECTIO_FALLBACK
+
+template <u8 pin>
+class InputLow {
+    // An active low digital input. read() returns true if the signal is asserted (low).
+    public:
+        InputLow() {}
+        boolean read() {
+            return ! input.read();
+        }
+        operator boolean() {
+            return read();
+        }
+
+    private:
+        Input<pin> input;
+};
+
+
+// This macro lets you temporarily set an output to a value,
+// and toggling back at the end of the code block. For example:
+//
+// Output<2> cs;
+// Output<3> data;
+// with(cs, LOW) {
+//     data = HIGH;
+// }
+//
+// is equivalent to:
+// cs = LOW;
+// data = HIGH;
+// cs = HIGH;
+
+#define with(pin, val) for(boolean _loop_##pin=((pin=val),true);_loop_##pin; _loop_##pin=((pin=!val), false))
+
+template <>
+class Output<NO_PIN> {
+    // This specialization of Output is used when a module supports
+    // an optional pin and that pin is not being used. For example,
+    // if a chip supports an Output Enable pin but it is wired
+    // permanently HIGH in the circuit, there won't be an actual
+    // output pin connected to it. In the software, we will use this
+    // type of Output which is basically a no-op.
+    public:
+        Output(boolean initial_value=LOW) {}
+        void write(boolean value) {}
+        Output& operator =(boolean value) {
+            return *this;
+        }
+        void toggle() {}
+        void pulse(boolean value=HIGH) {}
+
+        boolean read() {
+            return LOW;
+        }
+        operator boolean() {
+            return read();
+        }
+};
+
 
 template<u8 pin>
 class AnalogInput {

--- a/base.h
+++ b/base.h
@@ -22,7 +22,7 @@
 
 #include <Arduino.h>
 
-#if ARDUINO >= 150
+#if ARDUINO >= 150 && defined(ARDUINO_ARCH_AVR)
 // for u8, u16, u32
 #include <USBAPI.h>
 #else

--- a/ports.h
+++ b/ports.h
@@ -20,6 +20,12 @@
 #ifndef _PORTS_H
 #define _PORTS_H 1
 
+#if !defined(ARDUINO_ARCH_AVR)
+#warning "Unsupported Arduino variant - falling back to digitalRead and digitalWrite. If you are using Arduino IDE 1.0, be sure to #define an Arduino variant (e.g. #define ARDUINO_AVR_UNO 1). See ports.h."
+#define DIRECTIO_FALLBACK 1
+#include "base.h"
+#else
+
 #undef _AVR_COMMON_H
 #undef _AVR_IO_H_
 #undef _AVR_IOXXX_H_
@@ -34,7 +40,7 @@
 // avr/eeprom.h isn't compatible with _SFR_ASM_COMPAT, so prevent its inclusion
 #define _AVR_EEPROM_H_ 1
 
-#include <base.h>
+#include "base.h"
 #undef _SFR_ASM_COMPAT
 #undef _AVR_EEPROM_H_
 #endif // _AVR_EEPROM_H_
@@ -270,12 +276,6 @@ _define_pin(27, PORT_B, 5);
 _define_pin(28, PORT_B, 6);
 _define_pin(29, PORT_D, 6);
 
-#else
-
-#warning "Unsupported Arduino variant - falling back to digitalRead and digitalWrite. If you are using Arduino IDE 1.0, be sure to #define an Arduino variant (e.g. #define ARDUINO_AVR_UNO 1). See ports.h."
-
-#define DIRECTIO_FALLBACK 1
-
 #endif
 
 #undef _define_pin
@@ -290,5 +290,5 @@ _define_pin(29, PORT_D, 6);
 
 #include <util/atomic.h>
 #define atomic ATOMIC_BLOCK(ATOMIC_RESTORESTATE)
-
+#endif // ARDUINO_ARCH_AVR
 #endif  // _PORTS_H

--- a/ports.h
+++ b/ports.h
@@ -272,29 +272,9 @@ _define_pin(29, PORT_D, 6);
 
 #else
 
-#warning "Unsupported Arduino variant - assuming a Standard variant. If you are using Arduino IDE 1.0, be sure to #define an Arduino variant (e.g. #define ARDUINO_AVR_UNO 1). See ports.h."
+#warning "Unsupported Arduino variant - falling back to digitalRead and digitalWrite. If you are using Arduino IDE 1.0, be sure to #define an Arduino variant (e.g. #define ARDUINO_AVR_UNO 1). See ports.h."
 
-// same as standard variant above
-_define_pin(0, PORT_D, 0);
-_define_pin(1, PORT_D, 1);
-_define_pin(2, PORT_D, 2);
-_define_pin(3, PORT_D, 3);
-_define_pin(4, PORT_D, 4);
-_define_pin(5, PORT_D, 5);
-_define_pin(6, PORT_D, 6);
-_define_pin(7, PORT_D, 7);
-_define_pin(8, PORT_B, 0);
-_define_pin(9, PORT_B, 1);
-_define_pin(10, PORT_B, 2);
-_define_pin(11, PORT_B, 3);
-_define_pin(12, PORT_B, 4);
-_define_pin(13, PORT_B, 5);
-_define_pin(14, PORT_C, 0);
-_define_pin(15, PORT_C, 1);
-_define_pin(16, PORT_C, 2);
-_define_pin(17, PORT_C, 3);
-_define_pin(18, PORT_C, 4);
-_define_pin(19, PORT_C, 5);
+#define DIRECTIO_FALLBACK 1
 
 #endif
 


### PR DESCRIPTION
This PR implements a fallback mode for non-AVR Arduinos. The fallback mode uses digitalRead and digitalWrite, so there is no speedup. However, it removes the portability issue for sketches and libraries that use DirectIO. It should be possible to get some speedup on the other systems using the same techniques as for AVR.