### PR TITLE
Fix missing headers

### DIFF
--- a/include/boards/avr/eightanaloginputs.h
+++ b/include/boards/avr/eightanaloginputs.h
@@ -1,0 +1,22 @@
+// DirectIO support for eightanaloginputs
+
+_define_pin(0, PORT_D, 0);
+_define_pin(1, PORT_D, 1);
+_define_pin(2, PORT_D, 2);
+_define_pin(3, PORT_D, 3);
+_define_pin(4, PORT_D, 4);
+_define_pin(5, PORT_D, 5);
+_define_pin(6, PORT_D, 6);
+_define_pin(7, PORT_D, 7);
+_define_pin(8, PORT_B, 0);
+_define_pin(9, PORT_B, 1);
+_define_pin(10, PORT_B, 2);
+_define_pin(11, PORT_B, 3);
+_define_pin(12, PORT_B, 4);
+_define_pin(13, PORT_B, 5);
+_define_pin(14, PORT_C, 0);
+_define_pin(15, PORT_C, 1);
+_define_pin(16, PORT_C, 2);
+_define_pin(17, PORT_C, 3);
+_define_pin(18, PORT_C, 4);
+_define_pin(19, PORT_C, 5);

--- a/include/boards/avr/micro.h
+++ b/include/boards/avr/micro.h
@@ -1,0 +1,33 @@
+// DirectIO support for micro
+
+_define_pin(0, PORT_D, 2);
+_define_pin(1, PORT_D, 3);
+_define_pin(2, PORT_D, 1);
+_define_pin(3, PORT_D, 0);
+_define_pin(4, PORT_D, 4);
+_define_pin(5, PORT_C, 6);
+_define_pin(6, PORT_D, 7);
+_define_pin(7, PORT_E, 6);
+_define_pin(8, PORT_B, 4);
+_define_pin(9, PORT_B, 5);
+_define_pin(10, PORT_B, 6);
+_define_pin(11, PORT_B, 7);
+_define_pin(12, PORT_D, 6);
+_define_pin(13, PORT_C, 7);
+_define_pin(14, PORT_B, 3);
+_define_pin(15, PORT_B, 1);
+_define_pin(16, PORT_B, 2);
+_define_pin(17, PORT_B, 0);
+_define_pin(18, PORT_F, 7);
+_define_pin(19, PORT_F, 6);
+_define_pin(20, PORT_F, 5);
+_define_pin(21, PORT_F, 4);
+_define_pin(22, PORT_F, 1);
+_define_pin(23, PORT_F, 0);
+_define_pin(24, PORT_D, 4);
+_define_pin(25, PORT_D, 7);
+_define_pin(26, PORT_B, 4);
+_define_pin(27, PORT_B, 5);
+_define_pin(28, PORT_B, 6);
+_define_pin(29, PORT_D, 6);
+_define_pin(30, PORT_D, 5);

--- a/include/boards/avr/yun.h
+++ b/include/boards/avr/yun.h
@@ -1,0 +1,33 @@
+// DirectIO support for yun
+
+_define_pin(0, PORT_D, 2);
+_define_pin(1, PORT_D, 3);
+_define_pin(2, PORT_D, 1);
+_define_pin(3, PORT_D, 0);
+_define_pin(4, PORT_D, 4);
+_define_pin(5, PORT_C, 6);
+_define_pin(6, PORT_D, 7);
+_define_pin(7, PORT_E, 6);
+_define_pin(8, PORT_B, 4);
+_define_pin(9, PORT_B, 5);
+_define_pin(10, PORT_B, 6);
+_define_pin(11, PORT_B, 7);
+_define_pin(12, PORT_D, 6);
+_define_pin(13, PORT_C, 7);
+_define_pin(14, PORT_B, 3);
+_define_pin(15, PORT_B, 1);
+_define_pin(16, PORT_B, 2);
+_define_pin(17, PORT_B, 0);
+_define_pin(18, PORT_F, 7);
+_define_pin(19, PORT_F, 6);
+_define_pin(20, PORT_F, 5);
+_define_pin(21, PORT_F, 4);
+_define_pin(22, PORT_F, 1);
+_define_pin(23, PORT_F, 0);
+_define_pin(24, PORT_D, 4);
+_define_pin(25, PORT_D, 7);
+_define_pin(26, PORT_B, 4);
+_define_pin(27, PORT_B, 5);
+_define_pin(28, PORT_B, 6);
+_define_pin(29, PORT_D, 6);
+_define_pin(30, PORT_D, 5);

--- a/tools/gen_pins.py
+++ b/tools/gen_pins.py
@@ -76,7 +76,7 @@ def read_avr_variant(variant_file):
 	pin_num = 0
 	port_re = re.compile('\s*P(?:ORT_)?([A-L])')
 	pin_re = re.compile('\s*_BV\(\s*([0-9]+)\s*\)')
-	include_re = re.compile('#include "\.\./([^/]+)/pins_arduino.h"')
+	include_re = re.compile('#include "(\.\./[^/]+/pins_arduino.h)"')
 
 	if variant_file.endswith('pins_arduino.c'):
 		print('Warning: check generated pins for %s; multiple MCU variants may be combined' % variant_file)
@@ -107,7 +107,9 @@ def read_avr_variant(variant_file):
 				m = include_re.match(line)
 				if m:
 					found_include = True
-					print('%s -> %s' % (variant_file, m.group()))
+					target = m.group(1)
+					print('%s -> %s' % (variant_file, target))
+					return read_avr_variant(join(dirname(variant_file), target))
 
 		if len(ports) != len(pins):
 			error('ports/pins mismatch in %s (%d ports, %d pins)' % (variant_file, len(ports), len(pins)))


### PR DESCRIPTION
The gen-pins.py tool was detecting includes, but not following them to the target file containing the pin definitions. This resulted in 3 board include files being missing.

Fixes #20 
