### PR TITLE
Add pullup option for InputLow

### DIFF
--- a/DirectIO.h
+++ b/DirectIO.h
@@ -309,7 +309,7 @@ template <u8 pin>
 class InputLow {
     // An active low digital input. read() returns true if the signal is asserted (low).
     public:
-        InputLow() {}
+        InputLow(boolean pullup=true) : input(pullup) {}
         boolean read() {
             return ! input.read();
         }


### PR DESCRIPTION
Enable the inverted input to remove pullup.
When initializing `InputLow`, pass the `pullup` value to the underlaying `Input`:
`InputLow(boolean pullup=true) : input(pullup) {}`