### PR TITLE
Fix port definition for ItsyBitsy M0 and M4

### DIFF
--- a/include/ports_samd.h
+++ b/include/ports_samd.h
@@ -142,10 +142,10 @@ template <u8 pin> struct _pins {};
 #include "boards/samd/gemma_m0.h"
 #elif defined(ARDUINO_TRINKET_M0)
 #include "boards/samd/trinket_m0.h"
-#elif defined(ARDUINO_ITSYBITSY_M4)
+#elif defined(ARDUINO_ITSYBITSY_M0)
 #include "boards/samd/itsybitsy_m0.h"
 #elif defined(ARDUINO_ITSYBITSY_M4)
-#include "boards/samd/itsybitsy_m0.h"
+#include "boards/samd/itsybitsy_m4.h"
 #elif defined(ARDUINO_SAMD_HALLOWING)
 #include "boards/samd/hallowing_m0_express.h"
 #elif defined(ARDUINO_PIRKEY)


### PR DESCRIPTION
Fix a typo that prevented the Adafruit ItsyBitsy M0 and M4 boards from working.